### PR TITLE
Fix PATH export so nightly mirrors release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -296,6 +296,7 @@ jobs:
             - name: Build Universal Project (Device & Simulator) for Windows
               run: |
                   export PLAYDATE_SDK_PATH="$(pwd)/PlaydateSDK"
+                  export PATH="$(pwd)/gcc-arm-toolchain/bin:$PATH"
                   # Create build directory
                   mkdir -p build
                   


### PR DESCRIPTION
We had to add `arm-none-eibi-gcc` to the path like we did in the release workflow, oops!